### PR TITLE
Remove emit prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,13 +185,6 @@ For examples and usage please check the [examples folder](https://github.com/zcu
 
 Options for Plyr player. Documentation for Plyr options can be found [here](https://github.com/sampotts/plyr#options).
 
-### emit
-
-- **Type**: `Object`
-- **Default**: `[]`
-
-Array of events to be emitted.
-
 ### sources
 
 - **Type**: `Array`
@@ -258,37 +251,23 @@ Example:
 
 ## Events
 
-For capturing events from the `plyr` player, use `ref`.
-Events provided by `plyr` are documented [here](https://github.com/sampotts/plyr#events).
+`Plyrue` component supports `plyr` events.
+Events are documented [here](https://github.com/sampotts/plyr#events).
 
 ```vue
 <template>
-  <plyrue ref="plyrue" ... />
+  <plyrue @playing="handlePlaying" ... />
 </template>
 
 <script>
 export default {
-  mounted() {
-    this.player.on('some event', () => console.warn('some event fired'));
-  },
-  computed: {
-    player() {
-      return this.$refs.plyrue.player;
-    },
-  },
+  methods: { 
+    handlePlaying(event) {}
+  }
 };
 </script>
 ```
 
-Another option is to pass array of events as prop:
-
-```vue
-<plyrue
-  :emit="['timeupdate', 'exitfullscreen']"
-  @timeupdate="videoTimeUpdated"
-  @exitfullscreen="exitedFullScreen"
-/>
-```
 
 ## Development
 

--- a/src/components/Plyrue.vue
+++ b/src/components/Plyrue.vue
@@ -2,7 +2,7 @@
   <div class="plyrue">
     <component :is="component" v-bind="$attrs">
       <template v-for="(_, slot) of $scopedSlots" v-slot:[slot]="scope">
-        <slot :name="slot" v-bind="scope"/>
+        <slot :name="slot" v-bind="scope" />
       </template>
     </component>
   </div>
@@ -27,16 +27,15 @@ export default {
       type: Object,
       default: () => ({}),
     },
-    emit: {
-      type: Array,
-      default: () => [],
-    },
   },
   mounted() {
-    const { $el, options, emit, emitPlayerEvent } = this;
+    const { $el, options, emitPlayerEvent } = this;
     this.player = new Plyr($el.firstChild, options);
     this.$emit('player', this.player);
-    emit.forEach(el => this.player.on(el, emitPlayerEvent));
+    const events = Object.keys(this.$listeners);
+    events.forEach(event => {
+      this.player.on(event, emitPlayerEvent);
+    });
   },
   beforeDestroy() {
     try {

--- a/tests/plyrue.spec.js
+++ b/tests/plyrue.spec.js
@@ -30,6 +30,7 @@ describe('Plyrue component', () => {
   });
 
   it('emits event', () => {
+    const play = jest.fn();
     const wrapper = mount(Plyrue, {
       attachToDocument: true,
       attrs: {
@@ -37,9 +38,11 @@ describe('Plyrue component', () => {
         sources,
         src,
       },
+      listeners: { play }
     });
     wrapper.vm.emitPlayerEvent({ type: 'play' });
     expect(wrapper.emitted().play).toBeTruthy();
+    expect(play).toHaveBeenCalled()
   });
 
   it('catches Youtube error', () => {


### PR DESCRIPTION
### This PR:
Simplifies component API by removing `emit` prop
#### Changes:
- [x] removes redundant emit prop and instead attaches handlers to `plyr`'s events through `$listeners` instance property
- [x] updates component event usage examples and removes documentation about `emit` prop in the README
- [x] updates test for event emission by testing against handler being called